### PR TITLE
Allow a tab to be removed from the tab collection.

### DIFF
--- a/src/Clastic/BackofficeBundle/Form/TabHelper.php
+++ b/src/Clastic/BackofficeBundle/Form/TabHelper.php
@@ -64,4 +64,16 @@ class TabHelper
 
         return $tab;
     }
+
+    /**
+     * Remove a tab with a given name.
+     *
+     * @param string $name
+     *
+     * @return FormBuilderInterface The builder object.
+     */
+    public function removeTab($name)
+    {
+        return $this->formBuilder->get('tabs')->remove($name);
+    }
 }


### PR DESCRIPTION
In some cases, some default node tabs are not relevant (Publication for example). Therefore I would like to hide this tab on some node types to make sure I don't confuse my end-user.