### PR TITLE
Allow nodes to be altered before saving them

### DIFF
--- a/src/Clastic/NodeBundle/Controller/NodeController.php
+++ b/src/Clastic/NodeBundle/Controller/NodeController.php
@@ -11,6 +11,7 @@ namespace Clastic\NodeBundle\Controller;
 
 use Clastic\BackofficeBundle\Controller\AbstractModuleController;
 use Clastic\NodeBundle\Entity\Node;
+use Clastic\NodeBundle\Event\NodeFormPrePersistEvent;
 use Clastic\NodeBundle\Event\NodeFormPersistEvent;
 use Clastic\NodeBundle\Node\NodeManager;
 use Clastic\NodeBundle\Node\NodeReferenceInterface;
@@ -146,6 +147,9 @@ class NodeController extends AbstractModuleController
         /** @var Node $node */
         $node = $form->getData()->getNode();
         $node->setChanged(new \DateTime());
+
+        $this->get('event_dispatcher')
+          ->dispatch(NodeFormPrePersistEvent::NODE_FORM_PREPERSIST, new NodeFormPrePersistEvent($node, $form));
 
         $objectManager = $this->getDoctrine()->getManager();
         $objectManager->persist($form->getData());

--- a/src/Clastic/NodeBundle/Event/NodeFormPrePersistEvent.php
+++ b/src/Clastic/NodeBundle/Event/NodeFormPrePersistEvent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the Clastic package.
+ *
+ * (c) Dries De Peuter <dries@nousefreak.be>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Clastic\NodeBundle\Event;
+
+use Clastic\NodeBundle\Entity\Node;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\Form;
+
+/**
+ * @author Dries De Peuter <dries@nousefreak.be>
+ */
+class NodeFormPrePersistEvent extends Event
+{
+    const NODE_FORM_PREPERSIST = 'clastic.node.form.prepersist';
+
+    /**
+     * @var Node
+     */
+    private $node;
+
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * @param Node $node
+     * @param Form $form
+     */
+    public function __construct(Node $node, Form $form)
+    {
+        $this->node = $node;
+        $this->form = $form;
+    }
+
+    /**
+     * @return Node
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * @return Form
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+}


### PR DESCRIPTION
Added a new event to make sure node info can be altered before it is persisted to the database.

There was a NodeFormPersistEvent available but the node is already saved at that point...