### PR TITLE
[Menu] Fix create first menu item link.

### DIFF
--- a/src/Clastic/MenuBundle/Resources/views/Backoffice/item_list.html.twig
+++ b/src/Clastic/MenuBundle/Resources/views/Backoffice/item_list.html.twig
@@ -25,3 +25,7 @@
         <td></td>
     </tr>
 {% endblock %}
+
+{% block list_empty %}
+    {{ 'list.no_results'|trans }} <a href="{{ path('clastic_backoffice_menu_item_form', {menuId: menuId}) }}">Create your first.</a>
+{% endblock %}


### PR DESCRIPTION
The "create first item" link for menu items was pointing to a new menu, not a menu item.